### PR TITLE
Update keypair configuration output

### DIFF
--- a/docs/src/running-validator/validator-start.md
+++ b/docs/src/running-validator/validator-start.md
@@ -207,9 +207,11 @@ solana config set --keypair ~/validator-keypair.json
 You should see the following output:
 
 ```text
-Wallet Config Updated: /home/solana/.config/solana/wallet/config.yml
-* url: http://api.devnet.solana.com
-* keypair: /home/solana/validator-keypair.json
+Config File: /home/solana/.config/solana/cli/config.yml
+RPC URL: http://api.devnet.solana.com 
+WebSocket URL: ws://api.devnet.solana.com/ (computed)
+Keypair Path: /home/solana/validator-keypair.json 
+Commitment: confirmed
 ```
 
 ## Airdrop & Check Validator Balance


### PR DESCRIPTION
While going through the tutorial to start a validator I noticed that the output I received from running...

```
solana config set --keypair ~/validator-keypair.json
```

...differed from the output quoted in the docs. Wondering whether the docs are out of date I thought I'd propose an update just in case.